### PR TITLE
Weighted average stability

### DIFF
--- a/src/monitors/stability/__snapshots__/stability.test.js.snap
+++ b/src/monitors/stability/__snapshots__/stability.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Stability Monitor constructor initializes with the correct props 1`] = `
 StabilityMonitor {
-  "durationTotal": 0,
   "emitter": EventEmitter {
     "addEventListener": [MockFunction],
     "dispatchEvent": [MockFunction],
@@ -32,7 +31,8 @@ StabilityMonitor {
     },
   },
   "run": [Function],
+  "runningSpeedTotal": 0,
   "speedThreshold": 50,
-  "transferSizeTotal": 0,
+  "weightDivisor": 15,
 }
 `;

--- a/src/monitors/stability/index.js
+++ b/src/monitors/stability/index.js
@@ -11,7 +11,7 @@ class StabilityMonitor {
     ) {
         this.emitter = emitter
         this.maxBufferSize = maxBufferSize
-        this.divisor = (this.maxBufferSize * (this.maxBufferSize + 1)) / 2
+        this.weightDivisor = (this.maxBufferSize * (this.maxBufferSize + 1)) / 2
         this.speedThreshold = speedThreshold
         this.isStable = true
         this.run = this.run.bind(this)
@@ -51,9 +51,8 @@ class StabilityMonitor {
     }
 
     _emitStabilityChanges() {
-        console.log('this.runningSpeedTotal / this.divisor', this.runningSpeedTotal / this.divisor)
         const isThresholdHit =
-            this.runningSpeedTotal / this.divisor < this.speedThreshold
+            this.runningSpeedTotal / this.weightDivisor < this.speedThreshold
         if (this.isStable && isThresholdHit) {
             this.isStable = false
             this.emitter.dispatchEvent(NetworkStatus.UNSTABLE)


### PR DESCRIPTION
Changes the stability monitor calculations to use a weighted moving average over a simple moving average. The latest performance entries are weighted more heavily so the monitor should react to changes faster.

Still not entirely confident in the monitor defaults, but will put up a follow up PR after trying them on some bigger apps.