### PR TITLE
chore: remove greenkeeper config

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,9 +1,0 @@
-{
-  "groups": {
-    "default": {
-        "packages": [
-            "package.json"
-        ]
-    }
-  }
-}


### PR DESCRIPTION
Self-explanatory, GK is going out in early June, finishing up the migration to Dependabot.