### PR TITLE
Update Node on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 docker_defaults: &docker_defaults
   docker:
-    - image: circleci/node:8.14.0
+    - image: circleci/node:10.14.0
 
 commands:
   restore_env:


### PR DESCRIPTION
CI is currently running on Node 8.14, which is no longer LTS as of end of December 2019. Switching over to 10 allow for security updates on dependencies.